### PR TITLE
Add a tool for expected hash generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,8 @@ jobs:
           name: "Build for generic platform"
           command: |
               make -C opensbi O=$(pwd)/build PLATFORM_DIR=$(pwd)/plat/generic CROSS_COMPILE=riscv64-unknown-elf-
+              make hash -C tools FW_PATH=$(pwd)/build/platform/generic/firmware
+              cat tools/sm_expected_hash.h
   build-platform-generic-32:
     executor: setup-rv32gc
     working_directory: /keystone/sm
@@ -76,6 +78,8 @@ jobs:
           command: |
               make -C opensbi O=$(pwd)/build PLATFORM_DIR=$(pwd)/plat/generic CROSS_COMPILE=riscv32-unknown-elf- \
                 PLATFORM_RISCV_XLEN=32 PLATFORM_RISCV_ISA=rv32imafd PLATFORM_RISCV_ABI=ilp32d
+              make hash -C tools FW_PATH=$(pwd)/build/platform/generic/firmware
+              cat tools/sm_expected_hash.h
   build-platform-sifive-fu540:
     executor: setup-rv64gc
     working_directory: /keystone/sm
@@ -87,6 +91,8 @@ jobs:
           name: "Build for sifive/fu540 platform"
           command: |
               make -C opensbi O=$(pwd)/build PLATFORM_DIR=$(pwd)/plat/sifive/fu540 CROSS_COMPILE=riscv64-unknown-elf-
+              make hash -C tools FW_PATH=$(pwd)/build/platform/sifive/fu540/firmware
+              cat tools/sm_expected_hash.h
   unit-test-rv64:
     executor: setup-rv64gc
     working_directory: /keystone/sm

--- a/README.md
+++ b/README.md
@@ -67,3 +67,42 @@ cd build
 cmake ..
 make test
 ```
+
+## Hash Generation
+
+In order to perform remote attestation and verify the security monitor,
+you need an expected 64-byte hash of the security monitor firmware image.
+We provide a simple tool for generating a header `sm_expected_hash.h` that contains
+the expected hash for a given firmware image.
+
+```
+cd tools
+make
+make hash FW_PATH=<firmware path>
+```
+
+Where `<firmware path>` is the path containing OpenSBI's firmware images
+(i.e., `fw_payload.elf` and `fw_payload.bin`)
+
+The default `<firmware path>` is `../../build/sm.build/platform/generic/firmware`.
+Thus, if you have already built the security monitor in the Keystone build directory, you can just do
+
+```
+make hash
+```
+
+You can see the generated `sm_expected_hash.h` that you can use for the remote attestation.
+
+Here is an example:
+```cpp
+unsigned char sm_expected_hash[] = {
+  0x63,0x6a,0xc1,0x7c,0x15,0xb4,0x68,0xb9,
+  0x48,0x14,0xc7,0xaf,0xad,0xba,0xd3,0xc4,
+  0x57,0xd1,0xe3,0x68,0xc1,0x83,0x10,0xbd,
+  0x0d,0x9d,0x43,0x93,0x72,0xc2,0xc7,0x81,
+  0x27,0x17,0xb1,0x3f,0xda,0x8e,0x12,0x33,
+  0x5e,0xfe,0xdb,0xbc,0x5d,0x84,0x55,0x8f,
+  0xa3,0xb9,0x80,0xb2,0x47,0x87,0x67,0x1e,
+  0xcc,0x81,0x4a,0x8f,0xce,0xb3,0x30,0x1e,};
+unsigned int sm_expected_hash_len = 64;
+```

--- a/src/sha3/sha3.h
+++ b/src/sha3/sha3.h
@@ -4,7 +4,12 @@
 #ifndef SHA3_H
 #define SHA3_H
 
+#ifdef __riscv_xlen
 #include <sbi/sbi_types.h>
+#else
+#include <stdint.h>
+#include <stddef.h>
+#endif
 
 #ifndef KECCAKF_ROUNDS
 #define KECCAKF_ROUNDS 24

--- a/src/sm.c
+++ b/src/sm.c
@@ -89,6 +89,15 @@ void sm_copy_key()
   sbi_memcpy(dev_public_key, sanctum_dev_public_key, PUBLIC_KEY_SIZE);
 }
 
+void sm_print_hash()
+{
+  for (int i=0; i<MDSIZE; i++)
+  {
+    sbi_printf("%02x", (char) sm_hash[i]);
+  }
+  sbi_printf("\n");
+}
+
 /*
 void sm_print_cert()
 {
@@ -168,6 +177,8 @@ void sm_init(bool cold_boot)
   }
 
   sbi_printf("[SM] Keystone security monitor has been initialized!\n");
+
+  sm_print_hash();
 
   return;
   // for debug

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,0 +1,23 @@
+CC = gcc
+CFLAGS = -I../src -I../opensbi/include
+FW_PATH ?= ../../build/sm.build/platform/generic/firmware
+FW_ELF_PATH = $(FW_PATH)/fw_payload.elf
+FW_BIN_PATH = $(FW_PATH)/fw_payload.bin
+FW_SIZE = $(shell readelf --program-headers $(FW_ELF_PATH) | grep RWE | awk '{print $$2}')
+
+all: hashgen
+
+hashgen: sha3.o hash_generator.o
+	$(CC) $(CFLAGS) -o $@ $^
+
+sha3.o: ../src/sha3/sha3.c
+	$(CC) -c $^ $(CFLAGS)
+
+hash_generator.o: hash_generator.c
+	$(CC) -c $^ $(CFLAGS)
+
+hash: $(FW_ELF_PATH) $(FW_BIN_PATH) hashgen
+	./hashgen $(FW_BIN_PATH) $(FW_SIZE) > hash.h
+
+clean:
+	rm -f *.o hashgen hash.h

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -3,7 +3,7 @@ CFLAGS = -I../src -I../opensbi/include
 FW_PATH ?= ../../build/sm.build/platform/generic/firmware
 FW_ELF_PATH = $(FW_PATH)/fw_payload.elf
 FW_BIN_PATH = $(FW_PATH)/fw_payload.bin
-FW_SIZE = $(shell readelf --program-headers $(FW_ELF_PATH) | grep RWE | awk '{print $$2}')
+FW_SIZE = $(shell readelf --program-headers $(FW_ELF_PATH) | grep RWE | sed "s/^.*\(0x[0-9a-f]*\)[ \t]*\(RWE\).*$$/\1/")
 
 all: hashgen
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -17,7 +17,7 @@ hash_generator.o: hash_generator.c
 	$(CC) -c $^ $(CFLAGS)
 
 hash: $(FW_ELF_PATH) $(FW_BIN_PATH) hashgen
-	./hashgen $(FW_BIN_PATH) $(FW_SIZE) > hash.h
+	./hashgen $(FW_BIN_PATH) $(FW_SIZE) > sm_expected_hash.h
 
 clean:
-	rm -f *.o hashgen hash.h
+	rm -f *.o hashgen sm_expected_hash.h

--- a/tools/hash_generator.c
+++ b/tools/hash_generator.c
@@ -16,17 +16,14 @@ int main(int argc, char* argv[])
   unsigned char sm_hash[HASH_SIZE];
   unsigned char* buf;
   FILE* fw = fopen(argv[1],"rb");
-  int fsize;
+  int fwsize;
 
   if (!fw) {
     printf("File %s does not exist\n", argv[1]);
     return -1;
   }
 
-  // obtain file size:
-  fseek (fw, 0 , SEEK_END);
-  fsize = ftell (fw);
-  rewind (fw);
+  fwsize = strtol(argv[2], NULL, 16);
 
   // copy all file contents
   buf = (unsigned char*) malloc(FW_MEMORY_SIZE);
@@ -36,8 +33,8 @@ int main(int argc, char* argv[])
     return -1;
   }
 
-  int result = fread (buf,1,0x30a90,fw);
-  if (result != 0x30a90) {
+  int result = fread (buf,1,fwsize,fw);
+  if (result != fwsize) {
     printf("Failed to read file\n");
     return -1;
   }
@@ -56,7 +53,7 @@ int main(int argc, char* argv[])
     if (i % 8 == 0) {
       printf("\n");
     }
-    printf("\"0x%.2x\",", sm_hash[i]);
+    printf("0x%.2x,", sm_hash[i]);
   }
 
   printf("};\n");

--- a/tools/hash_generator.c
+++ b/tools/hash_generator.c
@@ -1,0 +1,66 @@
+#include <sha3/sha3.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#define FW_MEMORY_SIZE  0x1ff000
+#define HASH_SIZE       64
+
+int main(int argc, char* argv[])
+{
+  if (argc != 3) {
+    printf("Usage: %s <firmware> <fwsize>\n", argv[0]);
+    return 0;
+  }
+
+  unsigned char sm_hash[HASH_SIZE];
+  unsigned char* buf;
+  FILE* fw = fopen(argv[1],"rb");
+  int fsize;
+
+  if (!fw) {
+    printf("File %s does not exist\n", argv[1]);
+    return -1;
+  }
+
+  // obtain file size:
+  fseek (fw, 0 , SEEK_END);
+  fsize = ftell (fw);
+  rewind (fw);
+
+  // copy all file contents
+  buf = (unsigned char*) malloc(FW_MEMORY_SIZE);
+  memset(buf, 0, FW_MEMORY_SIZE);
+  if (!buf) {
+    printf("Failed to allocate buffer\n");
+    return -1;
+  }
+
+  int result = fread (buf,1,0x30a90,fw);
+  if (result != 0x30a90) {
+    printf("Failed to read file\n");
+    return -1;
+  }
+
+  fclose(fw);
+
+  sha3_ctx_t hash_ctx;
+  sha3_init(&hash_ctx, HASH_SIZE);
+  sha3_update(&hash_ctx, buf, FW_MEMORY_SIZE);
+  sha3_final(sm_hash, &hash_ctx);
+
+  printf("unsigned char sm_expected_hash[] = {");
+
+  for (int i=0; i < HASH_SIZE; i++)
+  {
+    if (i % 8 == 0) {
+      printf("\n");
+    }
+    printf("\"0x%.2x\",", sm_hash[i]);
+  }
+
+  printf("};\n");
+
+  printf("unsigned int sm_expected_hash_len = %d;\n", HASH_SIZE);
+  return 0;
+}


### PR DESCRIPTION
`hashgen` generates the expected hash of the security monitor.
It first reads the program header of the firmware and figures out the size of the initial memory the SM image takes.
The tool then copies the security monitor to a 2MB zeroed buffer and uses SHA3 to get the hash of the entire memory.
Usage of the tool was included in the README.md.