### PR TITLE
Update multimem SBIs to not output value in retval

### DIFF
--- a/src/mprv.h
+++ b/src/mprv.h
@@ -24,7 +24,7 @@ int copy_block_to_sm(mprv_block *dst, uintptr_t src);
 #define REGBYTES (1 << LOG_REGBYTES)
 #define MPRV_BLOCK (REGBYTES * 8)
 
-int copy_from_sm(uintptr_t dst, void *src_buf, size_t len)
+static inline int copy_from_sm(uintptr_t dst, void *src_buf, size_t len)
 {
     uintptr_t src = (uintptr_t)src_buf;
 
@@ -63,7 +63,7 @@ int copy_from_sm(uintptr_t dst, void *src_buf, size_t len)
     return 0;
 }
 
-int copy_to_sm(void *dst_buf, uintptr_t src, size_t len)
+static inline int copy_to_sm(void *dst_buf, uintptr_t src, size_t len)
 {
     uintptr_t dst = (uintptr_t)dst_buf;
 

--- a/src/plugins/multimem.c
+++ b/src/plugins/multimem.c
@@ -1,26 +1,34 @@
 #include "plugins/multimem.h"
 #include "sm.h"
+#include <sbi/sbi_console.h>
+#include "mprv.h"
 
-uintptr_t multimem_get_other_region_size(enclave_id eid)
+uintptr_t multimem_get_other_region_size(enclave_id eid, size_t *size_out)
 {
   int mem_id = get_enclave_region_index(eid, REGION_OTHER);
-  return get_enclave_region_size(eid, mem_id);
+  if (mem_id == -1)
+    return -1;
+  size_t out = get_enclave_region_size(eid, mem_id);
+  return copy_word_from_sm((uintptr_t)size_out, &out);
 }
 
-uintptr_t multimem_get_other_region_addr(enclave_id eid)
+uintptr_t multimem_get_other_region_addr(enclave_id eid, size_t *size_out)
 {
   int mem_id = get_enclave_region_index(eid, REGION_OTHER);
-  return get_enclave_region_base(eid, mem_id);
+  if (mem_id == -1)
+    return -1;
+  size_t out = get_enclave_region_base(eid, mem_id);
+  return copy_word_from_sm((uintptr_t)size_out, &out);
 }
 
-uintptr_t do_sbi_multimem(enclave_id eid, uintptr_t call_id)
+uintptr_t do_sbi_multimem(enclave_id eid, uintptr_t call_id, uintptr_t arg0)
 {
   switch(call_id)
   {
     case MULTIMEM_GET_OTHER_REGION_SIZE:
-      return multimem_get_other_region_size(eid);
+      return multimem_get_other_region_size(eid, (size_t *)arg0);
     case MULTIMEM_GET_OTHER_REGION_ADDR:
-      return multimem_get_other_region_addr(eid);
+      return multimem_get_other_region_addr(eid, (size_t *)arg0);
     default:
       return 0;
   }

--- a/src/plugins/multimem.h
+++ b/src/plugins/multimem.h
@@ -7,6 +7,6 @@
 #define MULTIMEM_GET_OTHER_REGION_SIZE 0x1
 #define MULTIMEM_GET_OTHER_REGION_ADDR 0x2
 
-uintptr_t do_sbi_multimem(enclave_id id, uintptr_t call_id);
+uintptr_t do_sbi_multimem(enclave_id id, uintptr_t call_id, uintptr_t arg0);
 
 #endif

--- a/src/plugins/plugins.c
+++ b/src/plugins/plugins.c
@@ -15,7 +15,7 @@ call_plugin(
   switch(plugin_id) {
 #ifdef PLUGIN_ENABLE_MULTIMEM
     case PLUGIN_ID_MULTIMEM:
-      return do_sbi_multimem(id, call_id);
+      return do_sbi_multimem(id, call_id, arg0);
       break;
 #endif
     default:


### PR DESCRIPTION
OpenSBI doesn't allow arbitrary values in the SBI retval, so use arg0 to pass them instead.