### PR TITLE
Update OpenSBI to latest version, sbi_hsm_hart_started_mask() rename.

### DIFF
--- a/src/ipi.c
+++ b/src/ipi.c
@@ -23,7 +23,7 @@ void send_and_sync_pmp_ipi(int region_idx, int type, uint8_t perm)
   ulong mask = 0;
   ulong source_hart = current_hartid();
   struct sbi_tlb_info tlb_info;
-  sbi_hsm_hart_started_mask(sbi_domain_thishart_ptr(), 0, &mask);
+  sbi_hsm_hart_interruptible_mask(sbi_domain_thishart_ptr(), 0, &mask);
 
   SBI_TLB_INFO_INIT(&tlb_info, type, 0, region_idx, perm,
       sbi_pmp_ipi_local_update, source_hart);


### PR DESCRIPTION
Bump OpenSBI to latest version, requiring the function `sbi_hsm_hart_started_mask()` be renamed to `sbi_hsm_interruptible_mask()`. See the name change [here](https://github.com/riscv-software-src/opensbi/commit/7c867fd19f92ac36aa2cd329f1eb687c6e630a26).